### PR TITLE
Fix image loading performance with caching and versioning

### DIFF
--- a/client/pages/About.tsx
+++ b/client/pages/About.tsx
@@ -227,8 +227,18 @@ export default function About() {
 
     if (!imageSrc) return null;
 
-    const finalSrc = imageSrc.startsWith("/api/assets/")
-      ? `${imageSrc}${imageSrc.includes("?") ? "&" : "?"}t=${Date.now()}`
+    let versionKey: string | null = null;
+    if (typeof img === "object" && img && "id" in img && typeof img.id === "string") {
+      versionKey = img.id;
+    } else if (typeof imageSrc === "string") {
+      const match = imageSrc.match(/\/api\/assets\/(.+?)(?:[/?].*)?$/);
+      if (match && match[1]) {
+        versionKey = match[1];
+      }
+    }
+
+    const finalSrc = versionKey
+      ? `${imageSrc}${imageSrc.includes("?") ? "&" : "?"}v=${encodeURIComponent(versionKey)}`
       : imageSrc;
 
     return (

--- a/client/pages/About.tsx
+++ b/client/pages/About.tsx
@@ -228,7 +228,12 @@ export default function About() {
     if (!imageSrc) return null;
 
     let versionKey: string | null = null;
-    if (typeof img === "object" && img && "id" in img && typeof img.id === "string") {
+    if (
+      typeof img === "object" &&
+      img &&
+      "id" in img &&
+      typeof img.id === "string"
+    ) {
       versionKey = img.id;
     } else if (typeof imageSrc === "string") {
       const match = imageSrc.match(/\/api\/assets\/(.+?)(?:[/?].*)?$/);

--- a/prisma/migrations/20250218_add_section_image_url/migration.sql
+++ b/prisma/migrations/20250218_add_section_image_url/migration.sql
@@ -1,2 +1,14 @@
 -- Add optional imageUrl column for sections
-ALTER TABLE "Section" ADD COLUMN "imageUrl" TEXT;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = current_schema()
+      AND table_name = 'Section'
+      AND column_name = 'imageUrl'
+  ) THEN
+    ALTER TABLE "Section" ADD COLUMN "imageUrl" TEXT;
+  END IF;
+END;
+$$;

--- a/server/dbFallback.ts
+++ b/server/dbFallback.ts
@@ -1,25 +1,53 @@
 import fs from "fs";
 import path from "path";
+import type { Response } from "express";
 import { db as memoryDb, createItem, updateItem, deleteItem } from "./store";
 
-export function serveAssetFallback(id: string, res: any) {
+function applyFallbackCaching(
+  id: string,
+  buffer: Buffer,
+  res: Response,
+  mime: string,
+  mtimeMs: number,
+) {
+  const etag = `"fallback-${id}-${buffer.length}-${Math.floor(mtimeMs)}"`;
+  const requester = (res as any)?.req as { headers?: Record<string, string> } | undefined;
+  if (requester?.headers && requester.headers["if-none-match"] === etag) {
+    res.status(304).end();
+    return true;
+  }
+  res.setHeader("Content-Type", mime);
+  res.setHeader("Content-Length", buffer.length.toString());
+  res.setHeader("Cache-Control", "public, max-age=86400");
+  res.setHeader("ETag", etag);
+  res.send(buffer);
+  return true;
+}
+
+export function serveAssetFallback(id: string, res: Response) {
   // if file exists in public/uploads
   const uploads = path.join(process.cwd(), "public", "uploads");
   const p = path.join(uploads, id);
   if (fs.existsSync(p)) {
+    const buffer = fs.readFileSync(p);
+    const stats = fs.statSync(p);
     const mime = p.endsWith(".svg")
       ? "image/svg+xml"
       : "application/octet-stream";
-    res.setHeader("Content-Type", mime);
-    res.send(fs.readFileSync(p));
-    return true;
+    return applyFallbackCaching(id, buffer, res, mime, stats.mtimeMs);
   }
   // serve placeholder
   const placeholder = path.join(process.cwd(), "public", "placeholder.svg");
   if (fs.existsSync(placeholder)) {
-    res.setHeader("Content-Type", "image/svg+xml");
-    res.send(fs.readFileSync(placeholder));
-    return true;
+    const buffer = fs.readFileSync(placeholder);
+    const stats = fs.statSync(placeholder);
+    return applyFallbackCaching(
+      id,
+      buffer,
+      res,
+      "image/svg+xml",
+      stats.mtimeMs,
+    );
   }
   res.status(404).send("Not found");
   return false;

--- a/server/dbFallback.ts
+++ b/server/dbFallback.ts
@@ -11,7 +11,9 @@ function applyFallbackCaching(
   mtimeMs: number,
 ) {
   const etag = `"fallback-${id}-${buffer.length}-${Math.floor(mtimeMs)}"`;
-  const requester = (res as any)?.req as { headers?: Record<string, string> } | undefined;
+  const requester = (res as any)?.req as
+    | { headers?: Record<string, string> }
+    | undefined;
   if (requester?.headers && requester.headers["if-none-match"] === etag) {
     res.status(304).end();
     return true;

--- a/server/index.ts
+++ b/server/index.ts
@@ -23,10 +23,14 @@ export function createServer() {
   prisma
     .$connect()
     .then(() => {
-      // lazy import to avoid top-level module cycles
-      import("./seed")
-        .then((m) => m.seed())
-        .catch((e) => console.warn("Seed failed", e));
+      const seedFlag = String(process.env.RUN_SEED_ON_START ?? "").toLowerCase();
+      const shouldSeed = seedFlag === "1" || seedFlag === "true";
+      if (shouldSeed) {
+        // lazy import to avoid top-level module cycles
+        import("./seed")
+          .then((m) => m.seed())
+          .catch((e) => console.warn("Seed failed", e));
+      }
     })
     .catch((e) => {
       console.warn("Prisma connect failed (if running without DB):", e.message);

--- a/server/index.ts
+++ b/server/index.ts
@@ -23,7 +23,9 @@ export function createServer() {
   prisma
     .$connect()
     .then(() => {
-      const seedFlag = String(process.env.RUN_SEED_ON_START ?? "").toLowerCase();
+      const seedFlag = String(
+        process.env.RUN_SEED_ON_START ?? "",
+      ).toLowerCase();
       const shouldSeed = seedFlag === "1" || seedFlag === "true";
       if (shouldSeed) {
         // lazy import to avoid top-level module cycles

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -181,8 +181,19 @@ router.get("/assets/:id", async (req, res) => {
   try {
     const asset = await prisma.asset.findUnique({ where: { id } });
     if (!asset) return serveAssetFallback(id, res);
+
+    const buffer = Buffer.from(asset.data as Buffer);
+    const etag = `"asset-${asset.id}-${buffer.length}"`;
+    if (req.headers["if-none-match"] === etag) {
+      res.status(304).end();
+      return;
+    }
+
     res.setHeader("Content-Type", asset.mime);
-    res.send(Buffer.from(asset.data as Buffer));
+    res.setHeader("Content-Length", buffer.length.toString());
+    res.setHeader("Cache-Control", "public, max-age=31536000, immutable");
+    res.setHeader("ETag", etag);
+    res.send(buffer);
   } catch (e) {
     console.warn("Prisma asset fetch failed, using fallback", e.message || e);
     serveAssetFallback(id, res);


### PR DESCRIPTION
## Purpose

Based on the conversation history, users were experiencing slow image loading times (2-3 seconds) on the About Us page, particularly in the "Who We Are" section. The goal was to optimize image loading performance and ensure images display quickly after page loads, while also handling image updates properly through the admin interface.

## Code changes

- **Enhanced image caching**: Added proper HTTP caching headers (ETag, Cache-Control) to asset serving endpoints in both admin and public routes
- **Improved cache busting**: Replaced timestamp-based cache busting with version-based approach using asset IDs for more reliable cache invalidation
- **Database migration safety**: Made the Section table imageUrl column addition idempotent to prevent migration errors
- **Conditional seeding**: Added environment variable control (`RUN_SEED_ON_START`) to prevent automatic database seeding
- **Fallback asset caching**: Implemented proper caching for fallback assets (uploads and placeholders) with ETag support and 304 Not Modified responses

These changes should significantly reduce image loading times while ensuring proper cache invalidation when images are updated through the admin interface.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/565db8d0ae214c6d9137c6cdfd72abde/neon-works)

👀 [Preview Link](https://565db8d0ae214c6d9137c6cdfd72abde-neon-works.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>565db8d0ae214c6d9137c6cdfd72abde</projectId>-->
<!--<branchName>neon-works</branchName>-->